### PR TITLE
Add styled Q&A page

### DIFF
--- a/src/app/qanda/page.tsx
+++ b/src/app/qanda/page.tsx
@@ -1,12 +1,62 @@
 import Image from 'next/image';
 
-const UnderConstruction = () => {
+interface QAItem {
+  question: string;
+  answer: string;
+}
+
+const qaData: QAItem[] = [
+  {
+    question:
+      'Wie habt ihr euch als Autorinnen-Duo gefunden und wie teilt ihr euch das Schreiben auf?',
+    answer: 'To Do',
+  },
+  {
+    question: 'Was hat euch zu der Welt von Sternendämmerung inspiriert?',
+    answer: 'To Do',
+  },
+  {
+    question: 'Gibt es Figuren in euren Büchern, mit denen ihr euch besonders identifiziert?',
+    answer: 'To Do',
+  },
+  {
+    question:
+      'Wie unterscheidet sich die Dreamer-Reihe stilistisch oder thematisch von der Sternendämmerung-Trilogie?',
+    answer: 'To Do',
+  },
+  {
+    question: 'Welche Bedeutung haben Träume und Sterne in euren Geschichten?',
+    answer: 'To Do',
+  },
+  {
+    question:
+      'Wie lange arbeitet ihr an einem Buch – von der ersten Idee bis zur Veröffentlichung?',
+    answer: 'To Do',
+  },
+  {
+    question: 'Habt ihr beim Schreiben feste Rituale oder besondere Schreiborte?',
+    answer: 'To Do',
+  },
+  {
+    question: 'Dürfen wir uns auf eine Fortsetzung oder neue Welt nach Dreamer freuen?',
+    answer: 'To Do',
+  },
+  {
+    question: 'Wie reagiert ihr auf Fan-Theorien und Interpretationen eurer Bücher?',
+    answer: 'To Do',
+  },
+  {
+    question: 'Welche Romantasy-Autor*innen haben euch selbst geprägt?',
+    answer: 'To Do',
+  },
+];
+
+const QandAPage = () => {
   return (
-    <div className="w-full min-h-screen flex flex-col items-center justify-center">
-      {/* Display the first image as in About component */}
+    <div className="flex min-h-screen w-full flex-col items-center">
       <div className="w-full">
         <Image
-          src="/images/background2.PNG" // Replace with the actual path to your image
+          src="/images/background2.PNG"
           alt="Header Image"
           width={1427}
           height={321}
@@ -14,14 +64,18 @@ const UnderConstruction = () => {
           objectFit="cover"
         />
       </div>
-
-      {/* Under Construction Text */}
-      <div className="flex flex-col items-center justify-center mt-10">
-        <h1 className="text-4xl font-bold">Under Construction</h1>
-        <p className="text-lg mt-5">An der Seite wird noch getüftelt.</p>
+      <div className="mx-auto mt-10 flex w-full flex-col items-start px-4 sm:w-11/12 md:w-2/3">
+        {qaData.map((item, index) => (
+          <div key={index} className="mb-8 border-b pb-6 last:border-none">
+            <h2 className="mb-2 text-3xl font-bold">
+              {index + 1}. {item.question}
+            </h2>
+            <p className="text-xl">{item.answer}</p>
+          </div>
+        ))}
       </div>
     </div>
   );
 };
 
-export default UnderConstruction;
+export default QandAPage;


### PR DESCRIPTION
## Summary
- implement Q&A page with 10 provided questions and placeholder answers
- style the entries with borders for consistency

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_6870f248fa08832fbf78e4955b224141